### PR TITLE
fix(transactions,connection-pool): Investigate POS freeze when payment is started [775455]

### DIFF
--- a/src/com/triniforce/server/plugins/kernel/SrvSmartTranFactory.java
+++ b/src/com/triniforce/server/plugins/kernel/SrvSmartTranFactory.java
@@ -63,19 +63,20 @@ public class SrvSmartTranFactory implements ISrvSmartTranFactory {
 	public void pop() {
         try {
             ISrvSmartTran trn = SrvApiAlgs2.getIServerTran();
-
-            trn.close();
-            
             IPooledConnection pool = ApiStack.getApi().getIntfImplementor(
                     IPooledConnection.class);
             Connection con = ApiStack.getApi().getIntfImplementor(
                     Connection.class);
             try {
-                pool.returnConnection(con);
-            } catch (Throwable t) {
-                ApiAlgs.getLog(this).error("Error returning connection", t);
+                trn.close();
+            } finally {
+                try {
+                    pool.returnConnection(con);
+                } catch (Throwable t) {
+                    ApiAlgs.getLog(this).error("Error returning connection", t);
+                }
             }
-            
+
         } finally {
             ApiStack.popApi();
         }

--- a/src/com/triniforce/server/plugins/kernel/TFPooledConnection.java
+++ b/src/com/triniforce/server/plugins/kernel/TFPooledConnection.java
@@ -7,6 +7,7 @@ package com.triniforce.server.plugins.kernel;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -87,27 +88,29 @@ public class TFPooledConnection implements IPooledConnection{
 	
 	@Override
 	public String getInfo() {
-		
-		String s = "";
-		int i = 0;
-		for (IPooledConnection.StackTraceRec traceRec : m_conStack.values()) {
-            i =i + 1;
+        Collection<StackTraceRec> takenConnectionPoints = getTakenConnectionPoints();
+        String s = "";
+        int i = 0;
+        for (IPooledConnection.StackTraceRec traceRec : takenConnectionPoints) {
+            i = i + 1;
             s = s + "---- " + i + " ----" + "\n";
             for (StackTraceElement tr : traceRec.getTrace()) {
                 s = s + tr.toString() + "\n";
             }
         }
-		s = "MaxActive = " + m_ds.getMaxTotal() + "\n" + 
+        s = "MaxActive = " + m_ds.getMaxTotal() + "\n" +
             "NumActive = " + m_ds.getNumActive() + "\n" +
-            "MaxWaitMillis = "   + m_ds.getMaxWaitMillis()   + "\n" +	
-            "Total in conStack: " + i +  "\n" + s + "----" + "\n"; 
-		
-		return s;
+            "MaxWaitMillis = "   + m_ds.getMaxWaitMillis()   + "\n" +
+            "Total in conStack: " + i +  "\n" + s + "----" + "\n";
+
+        return s;
 	}
 
 	@Override
 	public Collection<StackTraceRec> getTakenConnectionPoints() {
-		return m_conStack.values();
-	}	
+        synchronized (this) {
+            return new ArrayList<StackTraceRec>(m_conStack.values());
+        }
+	}
     
 }

--- a/test/com/triniforce/server/plugins/kernel/SrvSmartTranFactoryTest2.java
+++ b/test/com/triniforce/server/plugins/kernel/SrvSmartTranFactoryTest2.java
@@ -2,11 +2,14 @@
  * Copyright(C) Triniforce
  * All Rights Reserved.
  *
- */ 
+ */
 package com.triniforce.server.plugins.kernel;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collection;
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
 
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.jmock.Expectations;
@@ -16,6 +19,7 @@ import com.triniforce.db.test.TFTestCase;
 import com.triniforce.server.plugins.kernel.SrvSmartTranFactory.EPoolConnectionError;
 import com.triniforce.server.plugins.kernel.TFPooledConnection.IStackTraceInfo;
 import com.triniforce.server.srvapi.IPooledConnection;
+import com.triniforce.server.srvapi.IPooledConnection.StackTraceRec;
 import com.triniforce.server.srvapi.ISrvPrepSqlGetter;
 import com.triniforce.server.srvapi.ISrvSmartTran;
 import com.triniforce.server.srvapi.ISrvSmartTranFactory;
@@ -23,7 +27,7 @@ import com.triniforce.utils.Api;
 import com.triniforce.utils.ApiStack;
 
 public class SrvSmartTranFactoryTest2 extends TFTestCase {
-    
+
     SrvSmartTranFactory m_factory = new SrvSmartTranFactory();
 
     public void testPop() throws SQLException {
@@ -44,21 +48,76 @@ public class SrvSmartTranFactoryTest2 extends TFTestCase {
                 one(pool).returnConnection(con);
                 one(trn).close();
             }});
-            
+
             m_factory.pop();
             context.assertIsSatisfied();
-            
+
+            // pop() must remove only the transaction API frame and leave the caller API on top.
             assertSame(topApi, ApiStack.getThreadApiContainer().getStack().peek());
         } finally{
             ApiStack.popApi();
-        } 
+        }
+    }
+
+    // Design: check out one real pooled connection, make transaction close throw,
+    // then verify pop() propagates that failure while returning the connection.
+    public void testPopReturnsConnectionWhenTranCloseThrows() throws SQLException {
+        Mockery context = new Mockery();
+        final ISrvSmartTran trn = context.mock(ISrvSmartTran.class);
+        final RuntimeException closeError = new RuntimeException("close failed");
+        Connection c = getDataSource().getConnection();
+        try {
+            BasicDataSource ds = new BasicDataSource() {
+                public Connection getConnection() throws SQLException {
+                    return c;
+                };
+            };
+            TFPooledConnection pool = new TFPooledConnection(ds, 10);
+
+            // Start from the real failure shape: one connection is checked out.
+            Connection con = pool.getPooledConnection();
+            assertEquals(1, pool.getTakenConnectionPoints().size());
+
+            // The parent API owns the pool; the transaction API owns the checked-out connection.
+            Api topApi = new Api();
+            topApi.setIntfImplementor(IPooledConnection.class, pool);
+            ApiStack.pushApi(topApi);
+            Api lowApi = new Api();
+            lowApi.setIntfImplementor(Connection.class, con);
+            lowApi.setIntfImplementor(ISrvSmartTran.class, trn);
+            ApiStack.pushApi(lowApi);
+
+            try{
+                context.checking(new Expectations(){{
+                    one(trn).close(); will(throwException(closeError));
+                }});
+
+                try {
+                    m_factory.pop();
+                    fail();
+                } catch (RuntimeException e) {
+                    // The cleanup must not hide the original transaction close failure.
+                    assertSame(closeError, e);
+                }
+                context.assertIsSatisfied();
+
+                // Most important assertion: throwing close must not leave the pool holder behind.
+                assertEquals(0, pool.getTakenConnectionPoints().size());
+            } finally{
+                ApiStack.popApi();
+            }
+        } finally{
+            if(!c.isClosed()) {
+                c.close();
+            }
+        }
     }
 
     public void testPush() throws SQLException {
         Mockery context = new Mockery();
         final IPooledConnection pool = context.mock(IPooledConnection.class);
         final Connection con = context.mock(Connection.class);
-        ISrvPrepSqlGetter getter = context.mock(ISrvPrepSqlGetter.class); 
+        ISrvPrepSqlGetter getter = context.mock(ISrvPrepSqlGetter.class);
         Api api = new Api();
         api.setIntfImplementor(IPooledConnection.class, pool);
         api.setIntfImplementor(ISrvPrepSqlGetter.class, getter);
@@ -71,76 +130,105 @@ public class SrvSmartTranFactoryTest2 extends TFTestCase {
                 will(returnValue(con));
                 one(con).setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
             }});
-            
+
             m_factory.push();
             context.assertIsSatisfied();
-            
+
             Connection con2 = ApiStack.getApi().getIntfImplementor(Connection.class);
             assertSame(con, con2);
             assertNotNull(ApiStack.getApi().queryIntfImplementor(ISrvSmartTran.class));
-            
+
             ApiStack.popApi();
             assertSame(api, ApiStack.getThreadApiContainer().getStack().peek());
         } finally{
             ApiStack.popApi();
         }
     }
-    
-	boolean DOTHROW = false;
+
+    boolean DOTHROW = false;
     public void testPushError() throws SQLException {
-    	Connection c = getDataSource().getConnection();
-    	try {
-	    		
-	    	BasicDataSource ds = new BasicDataSource() {
-	    		public Connection getConnection() throws SQLException {
-	    			if(DOTHROW)
-	    				throw new SQLException("testthrow");
-	    			return c;				
-	    		};
-	    	};
-	    	TFPooledConnection pool = new TFPooledConnection(ds, 10);
-	    	
-			ApiStack.pushInterface(IStackTraceInfo.class, new IStackTraceInfo() {
-				@Override
-				public String getInfo() {
-					return "t000";
-				}
-				
-			});
-			try {
-		    	
-		    	Mockery context = new Mockery();
-		        final Connection con = context.mock(Connection.class);
-		        ISrvPrepSqlGetter getter = context.mock(ISrvPrepSqlGetter.class); 
-		        Api api = new Api();
-		        api.setIntfImplementor(IPooledConnection.class, pool);
-		        api.setIntfImplementor(ISrvPrepSqlGetter.class, getter);
-		        api.setIntfImplementor(ISrvSmartTranFactory.class, m_factory);
-		        ApiStack.pushApi(api);
-		
-		        try{
-		
-		    		m_factory.push();
-		        	DOTHROW = true;
-			    	try {
-			    		m_factory.push();
-			    		fail();
-			    	}catch(EPoolConnectionError e) {
-			    		assertEquals(1, e.getPoints().size());
-			    		assertEquals("t000", e.getPoints().iterator().next().getInfo());
-			    	}
-			    	finally{
-			    		ApiStack.popApi();
-			    	}
-		        } finally{
-		            ApiStack.popApi();
-		        }
-			}finally{
-				ApiStack.popInterface(1);
-			}
-    	}finally {
-    		c.close();
-    	}
-    } 
+        Connection c = getDataSource().getConnection();
+        try {
+
+            BasicDataSource ds = new BasicDataSource() {
+                public Connection getConnection() throws SQLException {
+                    if(DOTHROW)
+                        throw new SQLException("testthrow");
+                    return c;
+                };
+            };
+            TFPooledConnection pool = new TFPooledConnection(ds, 10);
+
+            ApiStack.pushInterface(IStackTraceInfo.class, new IStackTraceInfo() {
+                @Override
+                public String getInfo() {
+                    return "t000";
+                }
+
+            });
+            try {
+
+                Mockery context = new Mockery();
+                final Connection con = context.mock(Connection.class);
+                ISrvPrepSqlGetter getter = context.mock(ISrvPrepSqlGetter.class);
+                Api api = new Api();
+                api.setIntfImplementor(IPooledConnection.class, pool);
+                api.setIntfImplementor(ISrvPrepSqlGetter.class, getter);
+                api.setIntfImplementor(ISrvSmartTranFactory.class, m_factory);
+                ApiStack.pushApi(api);
+
+                try{
+
+                    m_factory.push();
+                    DOTHROW = true;
+                    try {
+                        m_factory.push();
+                        fail();
+                    }catch(EPoolConnectionError e) {
+                        assertEquals(1, e.getPoints().size());
+                        assertEquals("t000", e.getPoints().iterator().next().getInfo());
+                        assertTrue(e.getMessage().contains("Total in conStack: 1"));
+                    }
+                    finally{
+                        ApiStack.popApi();
+                    }
+                } finally{
+                    ApiStack.popApi();
+                }
+            }finally{
+                ApiStack.popInterface(1);
+            }
+        }finally {
+            c.close();
+            DOTHROW = false;
+        }
+    }
+
+    public void testTakenConnectionPointsStableAfterReturn() throws SQLException {
+        Connection c = getDataSource().getConnection();
+        try {
+            BasicDataSource ds = new BasicDataSource() {
+                public Connection getConnection() throws SQLException {
+                    return c;
+                };
+            };
+            TFPooledConnection pool = new TFPooledConnection(ds, 10);
+            Connection pooled = pool.getPooledConnection();
+            Collection<StackTraceRec> points = pool.getTakenConnectionPoints();
+            Iterator<StackTraceRec> it = points.iterator();
+            assertTrue(it.hasNext());
+
+            pool.returnConnection(pooled);
+            try {
+                assertNotNull(it.next());
+            } catch (ConcurrentModificationException e) {
+                fail("diagnostic points must be stable while connections are returned");
+            }
+        }finally {
+            if(!c.isClosed()) {
+                c.close();
+            }
+        }
+    }
 
 }

--- a/uspecs/changes/archive/2607/2607021452-investigate-pos-freeze-on-payment/change.md
+++ b/uspecs/changes/archive/2607/2607021452-investigate-pos-freeze-on-payment/change.md
@@ -1,0 +1,101 @@
+---
+change_id: 2606301356-investigate-pos-freeze-on-payment
+type: fix
+scope: [transactions, connection-pool]
+issue_url: https://dev.untill.com/projects/#!775455
+---
+
+# Change request: Investigate POS freeze when payment is started
+
+## Why
+
+POS clients freeze when an operator starts a payment, blocking sales at the
+point of sale. Static analysis localized the cause to `SrvSmartTranFactory.pop()`:
+it returns the pooled connection only if `trn.close()` succeeds, so a throwing
+close (failed rollback or a rethrowing transaction extender) leaks the connection.
+Leaked connections accumulate until the pool reaches `maxTotal`, after which new
+requests block on connection acquisition (the freeze); the
+ConcurrentModificationException seen in the logs is a downstream masking symptom.
+Fixing the release path stops the leak and restores the POS under load.
+
+## What
+
+Symptom: Starting a payment on the POS makes the client hang with no response.
+
+```text
+POS client starts payment
+      |
+      v
+BasicServerInvoker.invokeService(): enterMode(Running) -> push() acquires connection
+      |
+      v
+payment transaction ends; leaveMode() -> SrvSmartTranFactory.pop()
+      |
+      v
+trn.close() throws (failed rollback        <-- fault: pop() then skips
+or rethrown transaction extender)              pool.returnConnection() (not in finally)
+      |
+      v
+connection never returned to pool (leaked); repeats until pool reaches maxTotal
+      |
+      v
+next payment: getPooledConnection() blocks up to maxWaitMillis; POS receives no response   (symptom)
+```
+
+See [fault.md](./fault.md) for the full causal chain, evidence, and the
+downstream ConcurrentModificationException that masks the pool diagnostic.
+
+Corrected behavior: Starting a payment does not block the POS; the server
+acquires a database connection promptly because pooled connections are released
+in a timely manner, and on genuine exhaustion the request fails fast with a
+clear diagnostic instead of hanging.
+
+## How
+
+Decisions:
+
+- Treat this as a two-stage change: first statically localize why pooled
+  connections stay checked out by auditing every `push()`/`pop()` and
+  `getPooledConnection()`/`returnConnection()` pairing for paths that acquire a
+  connection but fail to release it, then fix the identified holder.
+- Make the connection-metadata access thread-safe in `TFPooledConnection`
+  (`getInfo()` and `getTakenConnectionPoints()`), aligned with the existing
+  `synchronized(this)` used by `getPooledConnection`/`returnConnection`, so the
+  masking `ConcurrentModificationException` no longer replaces
+  `EPoolConnectionError` and the diagnostic that names connection holders
+  survives.
+- Confirm the running server's `BasicDataSource` settings (`maxTotal`,
+  `maxWaitMillis`, `blockWhenExhausted`) to quantify how long request threads
+  block before failing.
+
+Out of scope:
+
+- Migrating Firebird to 64-bit (infrastructure change tracked separately).
+- Reworking the connection-pool or transaction architecture beyond the
+  localized fault.
+
+References:
+
+- [pooled connection wrapper and getInfo()](../../../../../src/com/triniforce/server/plugins/kernel/TFPooledConnection.java)
+- [transaction push/pop that acquires and releases connections](../../../../../src/com/triniforce/server/plugins/kernel/SrvSmartTranFactory.java)
+- [pooled connection interface](../../../../../src/com/triniforce/server/srvapi/IPooledConnection.java)
+- [server enterMode that triggers push()](../../../../../src/com/triniforce/server/plugins/kernel/BasicServer.java)
+- [pool error and thread-safety tests](../../../../../test/com/triniforce/server/plugins/kernel/SrvSmartTranFactoryTest2.java)
+- [Apache Commons DBCP2 BasicDataSource configuration](https://commons.apache.org/proper/commons-dbcp/configuration.html)
+
+## Construction
+
+- [x] update: [kernel/SrvSmartTranFactoryTest2.java](../../../../../test/com/triniforce/server/plugins/kernel/SrvSmartTranFactoryTest2.java)
+  - add regression coverage for `SrvSmartTranFactory.pop()` when `ISrvSmartTran.close()` throws: verify the pooled `Connection` is still returned and the API stack is popped
+  - add coverage that a pool acquisition failure still reports the already-held connection points in `EPoolConnectionError`
+  - add coverage that pool diagnostics can be read while connections are returned without surfacing `ConcurrentModificationException`
+
+- [x] update: [kernel/SrvSmartTranFactory.java](../../../../../src/com/triniforce/server/plugins/kernel/SrvSmartTranFactory.java)
+  - capture the current `IPooledConnection` and `Connection` before closing the smart transaction
+  - return the connection in a `finally` path so `trn.close()` failures do not leak checked-out pooled connections
+  - preserve the transaction-close failure for callers after attempting connection return and keep `ApiStack.popApi()` in the outer cleanup path
+
+- [x] update: [kernel/TFPooledConnection.java](../../../../../src/com/triniforce/server/plugins/kernel/TFPooledConnection.java)
+  - synchronize `getInfo()` access to `m_conStack` with the same monitor used by checkout and return
+  - return a stable snapshot from `getTakenConnectionPoints()` so diagnostics cannot iterate over a mutating backing collection
+  - keep existing `BasicDataSource` diagnostic values (`maxTotal`, `numActive`, `maxWaitMillis`) intact

--- a/uspecs/changes/archive/2607/2607021452-investigate-pos-freeze-on-payment/fault.md
+++ b/uspecs/changes/archive/2607/2607021452-investigate-pos-freeze-on-payment/fault.md
@@ -1,0 +1,102 @@
+# Fault localization: POS freeze when payment is started
+
+Status: localized (static analysis only; not yet reproduced/verified)
+
+## Symptom
+
+Starting a payment hangs the POS. Server logs around incidents show connection
+pool exhaustion and a masking ConcurrentModificationException in the pool.
+
+## Localized fault
+
+File: src/com/triniforce/server/plugins/kernel/SrvSmartTranFactory.java
+Method: pop(), lines 63-82
+
+`trn.close()` is called before `pool.returnConnection(con)`, and
+`returnConnection` is NOT inside a finally that covers `trn.close()`. When
+`trn.close()` throws, control jumps straight to the `finally { ApiStack.popApi(); }`
+block, so `returnConnection` is skipped. The api entry is popped but the JDBC
+connection is never handed back to DBCP2 -> it stays "active" forever (leak).
+
+```text
+SrvSmartTranFactory.pop():
+    trn.close();                    <-- fault: may throw; if it does ...
+    ...
+    pool.returnConnection(con);     <-- ... this is skipped (not in finally)
+  finally:
+    ApiStack.popApi();              <-- only the api stack is unwound
+```
+
+## Why trn.close() can throw
+
+- src/com/triniforce/db/dml/SmartTran.java close(boolean) (lines 66-84):
+  no-arg `close()` -> `close(false)` -> `m_conn.rollback()`, wrapped with
+  `ApiAlgs.rethrowException(e)`. A failed rollback (broken connection, Firebird
+  fatal error) is rethrown as a RuntimeException.
+- src/com/triniforce/server/plugins/kernel/SrvSmartTran.java close(boolean)
+  (lines 50-118): captures the first inner ITranExtender.pop() failure in
+  `eFirstProblem` and rethrows it at the end (lines 113-115). So a misbehaving
+  inner extender makes close() throw even when the connection itself is healthy.
+
+## Causal chain to the symptom
+
+```text
+POS starts payment
+      |
+      v
+BasicServerInvoker.invokeService(): enterMode(Running) -> push() acquires connection
+      |
+      v
+service body throws OR commit deferred; finally -> leaveMode() -> SrvSmartTranFactory.pop()
+      |
+      v
+trn.close() throws (rollback fails OR inner extender pop() rethrown as eFirstProblem)
+      |
+      v
+pool.returnConnection(con) skipped   <-- connection leaked (never returned to DBCP2)
+      |
+      v
+leaked connections accumulate -> pool reaches maxTotal
+      |
+      v
+later push() -> getPooledConnection() blocks up to maxWaitMillis   (POS freeze)
+      |
+      v
+on timeout SQLException -> getInfo() iterates unsynchronized HashMap -> CME (masking log)
+```
+
+## Why this matches "freeze on payment"
+
+Payments are write transactions and the most likely to hit rollback/commit-time
+faults and extender failures, so they disproportionately trigger the throwing
+`close()` path - each occurrence leaks one connection until the pool is drained.
+
+## Consistency check
+
+A leaked connection is also never removed from `TFPooledConnection.m_conStack`
+(because `returnConnection`'s `m_conStack.remove(con)` never runs), so the
+leaked holders pile up in the same map that `getInfo()` later iterates - matching
+the observed CME location.
+
+## Secondary issue (not the freeze cause)
+
+`TFPooledConnection.getInfo()` / `getTakenConnectionPoints()` iterate `m_conStack`
+without synchronization while other threads mutate it under `synchronized(this)`.
+This only masks the informative EPoolConnectionError with a CME; it does not
+itself leak connections.
+
+## Recommended fix direction
+
+Make `pop()` release the connection unconditionally, e.g. move
+`pool.returnConnection(con)` into a `finally` that wraps `trn.close()`, so a
+throwing close still returns the connection. Then address the secondary CME by
+making the `m_conStack` reads in `TFPooledConnection` thread-safe.
+
+## Open questions / verification (for uimpl)
+
+- Confirm running server's BasicDataSource `maxTotal` / `maxWaitMillis` /
+  `blockWhenExhausted`.
+- Identify which inner/outer ITranExtenders are registered in production and
+  whether their pop() can throw during payment.
+- Add a regression test: pop() with a throwing trn.close() must still call
+  returnConnection (extend SrvSmartTranFactoryTest2).


### PR DESCRIPTION
```yaml
change_id: 2606301356-investigate-pos-freeze-on-payment
type: fix
scope: [transactions, connection-pool]
issue_url: https://dev.untill.com/projects/#!775455
```
## Why

POS clients freeze when an operator starts a payment, blocking sales at the
point of sale. Static analysis localized the cause to `SrvSmartTranFactory.pop()`:
it returns the pooled connection only if `trn.close()` succeeds, so a throwing
close (failed rollback or a rethrowing transaction extender) leaks the connection.
Leaked connections accumulate until the pool reaches `maxTotal`, after which new
requests block on connection acquisition (the freeze); the
ConcurrentModificationException seen in the logs is a downstream masking symptom.
Fixing the release path stops the leak and restores the POS under load.

## What

Symptom: Starting a payment on the POS makes the client hang with no response.

```text
POS client starts payment
      |
      v
BasicServerInvoker.invokeService(): enterMode(Running) -> push() acquires connection
      |
      v
payment transaction ends; leaveMode() -> SrvSmartTranFactory.pop()
      |
      v
trn.close() throws (failed rollback        <-- fault: pop() then skips
or rethrown transaction extender)              pool.returnConnection() (not in finally)
      |
      v
connection never returned to pool (leaked); repeats until pool reaches maxTotal
      |
      v
next payment: getPooledConnection() blocks up to maxWaitMillis; POS receives no response   (symptom)
```


---
Content omitted. See change.md for full details.
